### PR TITLE
Mnist example requires more driver and executor memory

### DIFF
--- a/bin/run-example
+++ b/bin/run-example
@@ -78,7 +78,7 @@ exec spark-submit \
   --packages "deeplearning4j:dl4j-spark-ml:0.4-rc0" \
   --master $EXAMPLE_MASTER \
   --class $EXAMPLE_CLASS \
-  --driver-memory 1G \
-  --executor-memory 4G \
+  --driver-memory 8G \
+  --executor-memory 8G \
   "$SPARK_EXAMPLES_JAR" \
   "$@"


### PR DESCRIPTION
In case of driver-memory 1G and executor-memory 4G, OOM has been occurred.
Because mnist example requires more driver and executor memory, change default values passed to `spark-submit`.  