### PR TITLE
JavaMnistClassification improvements (WIP)

### DIFF
--- a/bin/run-example
+++ b/bin/run-example
@@ -75,7 +75,7 @@ if [[ ! $EXAMPLE_CLASS == org.deeplearning4j* ]]; then
 fi
 
 exec spark-submit \
-  --packages "deeplearning4j:dl4j-spark-ml:0.4-rc0" \
+  --packages "deeplearning4j:dl4j-spark-ml:0.4-rc2.2" \
   --master $EXAMPLE_MASTER \
   --class $EXAMPLE_CLASS \
   --driver-memory 1G \

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
   <url>http://maven.apache.org</url>
 
   <properties>
-    <nd4j.version>0.4-rc0</nd4j.version>
-    <dl4j.version>0.4-rc0</dl4j.version>
+    <nd4j.version>0.4-rc2.2</nd4j.version>
+    <dl4j.version>0.4-rc2.2</dl4j.version>
     <spark.version>1.4.0</spark.version>
   </properties>
 

--- a/src/main/java/org/deeplearning4j/ml/JavaMnistClassification.java
+++ b/src/main/java/org/deeplearning4j/ml/JavaMnistClassification.java
@@ -7,22 +7,23 @@ import org.apache.spark.ml.PipelineModel;
 import org.apache.spark.ml.PipelineStage;
 import org.apache.spark.ml.feature.StandardScaler;
 import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
+import org.deeplearning4j.eval.Evaluation;
 import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
 import org.deeplearning4j.nn.conf.layers.OutputLayer;
-import org.deeplearning4j.nn.conf.layers.RBM;
 import org.deeplearning4j.nn.conf.layers.SubsamplingLayer;
-import org.deeplearning4j.nn.conf.preprocessor.CnnToFeedForwardPreProcessor;
-import org.deeplearning4j.nn.conf.preprocessor.FeedForwardToCnnPreProcessor;
+import org.deeplearning4j.nn.conf.layers.setup.ConvolutionLayerSetup;
 import org.deeplearning4j.nn.weights.WeightInit;
 import org.deeplearning4j.spark.ml.classification.NeuralNetworkClassification;
 import org.deeplearning4j.spark.sql.sources.mnist.DefaultSource;
+import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
+import org.nd4j.linalg.util.FeatureUtil;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,11 +38,7 @@ import java.util.Map;
  */
 public class JavaMnistClassification {
 
-    final static int numRows = 28;
-    final static int numColumns = 28;
     final static int outputNum = 10;
-    final static int iterations = 10;
-    final static int seed = 123;
 
     public static void main(String[] args) {
         SparkConf conf = new SparkConf()
@@ -56,6 +53,9 @@ public class JavaMnistClassification {
         Map<String, String> params = new HashMap<String, String>();
         params.put("imagesPath", imagesPath);
         params.put("labelsPath", labelsPath);
+        params.put("recordsPerPartition", "400");
+        params.put("maxRecords", "2000");
+
         DataFrame data = jsql.read().format(DefaultSource.class.getName())
                 .options(params).load();
 
@@ -66,11 +66,11 @@ public class JavaMnistClassification {
         DataFrame testData = data.except(trainingData);
 
         StandardScaler scaler = new StandardScaler()
-                .setWithMean(true).setWithStd(true)
                 .setInputCol("features")
                 .setOutputCol("scaledFeatures");
         NeuralNetworkClassification classification = new NeuralNetworkClassification()
                 .setFeaturesCol("scaledFeatures")
+                .setEpochs(2)
                 .setConf(getConfiguration());
         Pipeline pipeline = new Pipeline().setStages(new PipelineStage[]{
                 scaler, classification});
@@ -80,9 +80,20 @@ public class JavaMnistClassification {
 
         System.out.println("\nTesting...");
         DataFrame predictions = model.transform(testData);
+        predictions.cache();
 
         System.out.println("\nTest Results:");
         predictions.show(100);
+
+        Evaluation eval = new Evaluation(outputNum);
+        Row[] rows = predictions.select("label","prediction").collect();
+        for(int i = 0; i < rows.length; i++) {
+            INDArray label = FeatureUtil.toOutcomeVector((int) rows[i].getDouble(0), outputNum);
+            INDArray prediction = FeatureUtil.toOutcomeVector((int) rows[i].getDouble(1), outputNum);
+            eval.eval(label, prediction);
+        }
+
+        System.out.println(eval.stats());
     }
 
     public static MultiLayerConfiguration getConfiguration() {
@@ -91,12 +102,11 @@ public class JavaMnistClassification {
         final int numColumns = 28;
         int nChannels = 1;
         int outputNum = 10;
-        int numSamples = 2000;
         int batchSize = 500;
         int iterations = 10;
         int seed = 123;
 
-        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+        MultiLayerConfiguration.Builder builder = new NeuralNetConfiguration.Builder()
                 .seed(seed)
                 .batchSize(batchSize)
                 .iterations(iterations)
@@ -109,7 +119,7 @@ public class JavaMnistClassification {
                         .weightInit(WeightInit.XAVIER)
                         .activation("relu")
                         .build())
-                .layer(1, new SubsamplingLayer.Builder(SubsamplingLayer.PoolingType.MAX, new int[] {2,2})
+                .layer(1, new SubsamplingLayer.Builder(SubsamplingLayer.PoolingType.MAX, new int[]{2, 2})
                         .build())
                 .layer(2, new OutputLayer.Builder(LossFunctions.LossFunction.NEGATIVELOGLIKELIHOOD)
                         .nIn(150)
@@ -117,11 +127,10 @@ public class JavaMnistClassification {
                         .weightInit(WeightInit.XAVIER)
                         .activation("softmax")
                         .build())
-                .inputPreProcessor(0, new FeedForwardToCnnPreProcessor(numRows, numColumns, 1))
-                .inputPreProcessor(2, new CnnToFeedForwardPreProcessor())
-                .backprop(true).pretrain(false)
-                .build();
+                .backprop(true).pretrain(false);
+        new ConvolutionLayerSetup(builder, numRows, numColumns, nChannels);
 
+        MultiLayerConfiguration conf = builder.build();
         return conf;
     }
 }


### PR DESCRIPTION
- use 0.4-rc2.2
- print a confusion matrix
- use two epochs to improve predictions
- incorporate the ConvolutionLayerSetup class